### PR TITLE
Support custom arachni distributions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV ARACHNI_LONG_VERSION ${ARACHNI_LONG_VERSION}
 
 RUN wget ${ARACHNI_DISTRIBUTION} -P /sectools --output-document arachni.tar.gz && \
     tar zxvf arachni.tar.gz && \
-    mv arachni-${ARACHNI_FOLDER_NAME} arachni && \
+    mv arachni-${ARACHNI_LONG_VERSION} arachni && \
     rm arachni.tar.gz
 
 COPY Gemfile src/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /sectools/
 
 ARG ARACHNI_DISTRIBUTION=https://github.com/Arachni/arachni/releases/download/v1.5.1/arachni-1.5.1-0.5.12-linux-x86_64.tar.gz
 # Name of the arachni main folder contained in the .tar.gz
-ARG ARACHNI_LONG_VERSION=arachni-1.5.1-0.5.12
+ARG ARACHNI_LONG_VERSION=1.5.1-0.5.12
 
 ENV ARACHNI_LONG_VERSION ${ARACHNI_LONG_VERSION}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,16 @@ FROM ruby:latest
 
 WORKDIR /sectools/
 
-ENV ARACHNI_SHORT_VERSION v1.5.1
-ENV ARACHNI_LONG_VERSION 1.5.1-0.5.12
+ARG ARACHNI_DISTRIBUTION=https://github.com/Arachni/arachni/releases/download/v1.5.1/arachni-1.5.1-0.5.12-linux-x86_64.tar.gz
+# Name of the arachni main folder contained in the .tar.gz
+ARG ARACHNI_LONG_VERSION=arachni-1.5.1-0.5.12
 
-RUN wget https://github.com/Arachni/arachni/releases/download/${ARACHNI_SHORT_VERSION}/arachni-${ARACHNI_LONG_VERSION}-linux-x86_64.tar.gz -P /sectools && \
-    tar zxvf /sectools/* -C /sectools && \
-    rm /sectools/arachni-1.5.1-0.5.12-linux-x86_64.tar.gz
+ENV ARACHNI_LONG_VERSION ${ARACHNI_LONG_VERSION}
+
+RUN wget ${ARACHNI_DISTRIBUTION} -P /sectools --output-document arachni.tar.gz && \
+    tar zxvf arachni.tar.gz && \
+    mv arachni-${ARACHNI_FOLDER_NAME} arachni && \
+    rm arachni.tar.gz
 
 COPY Gemfile src/
 

--- a/src/starter.sh
+++ b/src/starter.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 ruby /sectools/src/main.rb & \
-bash /sectools/arachni-1.5.1-0.5.12/bin/arachni_rest_server
+bash /sectools/arachni/bin/arachni_rest_server


### PR DESCRIPTION
Exposing the url used to download the arachni binaries as docker build arg to exchange the standard arachni versions via custom ones to test and deploy fixes directly.

The default values for the build args are set to the previous values.