### PR TITLE
Added arguments to inject arguments into login scripts

### DIFF
--- a/src/arachni_worker.rb
+++ b/src/arachni_worker.rb
@@ -16,7 +16,7 @@ class ArachniWorker < CamundaWorker
 
   def work(job_id, targets)
     configs = targets.map {|target|
-      ArachniConfiguration.from_target target
+      ArachniConfiguration.from_target job_id, target
     }
 
     scans = configs.map { |config|

--- a/tests/arachni_result_transformer_test.rb
+++ b/tests/arachni_result_transformer_test.rb
@@ -176,7 +176,7 @@ EOM
         @transformer.transform(result),
         []
     )
-    end
+  end
 
   def test_add_a_timed_out_finding_when_optional_parameter_is_passed
 

--- a/tests/static/login.js
+++ b/tests/static/login.js
@@ -1,0 +1,3 @@
+let foo = "${FOO_BAR}";
+
+console.log(foo);


### PR DESCRIPTION
This allows to write generic login scripts without credentials in them.
This should also allow to write generic scripts which can be easily reused across an organisation.