### PR TITLE
Improve arachni result polling mechanics

### DIFF
--- a/src/arachni_scan.rb
+++ b/src/arachni_scan.rb
@@ -95,10 +95,18 @@ class ArachniScan
         audited_pages = response['statistics']['audited_pages']
         current_page = response['statistics']['current_page']
 
+        burst_average_response_time = response['statistics']['http']['burst_average_response_time']
+        total_average_response_time = response['statistics']['http']['total_average_response_time']
+
+        burst_responses_per_second = response['statistics']['http']['burst_responses_per_second']
+        total_responses_per_second = response['statistics']['http']['total_responses_per_second']
+
         $logger.info "Request made:  #{current_request_count}"
         $logger.info "Pages found:   #{found_pages}"
         $logger.info "Pages audited: #{audited_pages}"
         $logger.info "Current Page:  #{current_page}"
+        $logger.info "Burst Avg. Response Time: #{burst_average_response_time}s, Total Avg. Response Time: #{total_average_response_time}s"
+        $logger.info "Burst Requests: #{burst_responses_per_second}/s, Total Requests per Second: #{total_responses_per_second}/s"
 
         if current_request_count == last_request_count
           if Time.now > last_request_count_change + (5 * 60)

--- a/src/arachni_scan.rb
+++ b/src/arachni_scan.rb
@@ -76,7 +76,7 @@ class ArachniScan
         $logger.debug "Status endpoint returned #{request.code}"
         response = JSON.parse(request)
         $logger.debug "Checking status of scan '#{@scan_id}': currently busy: #{response['busy']}"
-      rescue RestClient::Exceptions::ReadTimeout => err
+      rescue RestClient::Exceptions::ReadTimeout
         timed_out_request_count += 1
 
         $logger.warn "Request to poll for current results timed out."


### PR DESCRIPTION
Improved how the scanner wrapper polls the arachni api server for the finished results.

- Use `/scans/:scanId/summary` instead of the full `/scans/:scanId/` endpoint. This greatly reduced load on the api server as the responses are way smaller.
- In case of polling timeouts the wrapper will only fail if it gets 10 consecutive timeouts / errors. If the wrapper get a successful response the counter is reset.
- Increased polling timeout from 2 to 5 seconds and the final result fetch timeout from 2 to 60